### PR TITLE
feat: add support to OAuthTokenVerifier and requireBearerAuth middleware

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -75,5 +75,5 @@ await app.ready();
 await app.listen({
   host: '127.0.0.1',
   port: 9080,
-  listenTextResolver: (address) => `MCP Streamable HTTP Server listening at ${address}`
+  listenTextResolver: (address) => `(Basic) MCP Streamable HTTP Server listening at ${address}`
 });

--- a/examples/bearer.ts
+++ b/examples/bearer.ts
@@ -1,0 +1,108 @@
+import type { OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import closeWithGrace from 'close-with-grace';
+import Fastify from 'fastify';
+
+import packageJson from '../package.json' with { type: 'json' };
+import FastifyMcpStreamableHttp, { getMcpDecorator } from '../src/index.ts';
+
+const app = Fastify({
+  logger: {
+    level: 'debug',
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        translateTime: 'HH:MM:ss Z',
+        ignore: 'pid,hostname'
+      }
+    }
+  },
+  disableRequestLogging: true
+});
+
+const mcp = new McpServer({
+  name: packageJson.name,
+  version: packageJson.version
+});
+
+mcp.tool('get-datetime', 'Get the current date and time', ({ authInfo }) => {
+  if (authInfo?.token !== 'valid-bearer-token') {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'This tool requires authentication. Please provide a valid Bearer token.'
+        }
+      ],
+      isError: true
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: new Intl.DateTimeFormat('en-US', {
+          day: '2-digit',
+          month: 'long',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false
+        }).format(new Date())
+      }
+    ]
+  };
+});
+
+class BearerTokenVerifier implements OAuthTokenVerifier {
+  verifyAccessToken (token: string): Promise<AuthInfo> {
+    // Just a mock implementation for demonstration purposes.
+    const authInfo = { token, clientId: 'example-client', scopes: [] } satisfies AuthInfo;
+    return new Promise((resolve) => {
+      resolve(authInfo);
+    });
+  }
+}
+
+await app.register(FastifyMcpStreamableHttp, {
+  server: mcp.server,
+  endpoint: '/mcp', // optional, defaults to '/mcp'
+  bearerAuthMiddlewareOptions: {
+    verifier: new BearerTokenVerifier()
+  }
+});
+
+const mcpServer = getMcpDecorator(app);
+
+// Setup event handlers after plugin registration
+mcpServer.sessionManager.on('sessionCreated', (sessionId) => {
+  app.log.info({ sessionId }, 'MCP session created');
+});
+
+mcpServer.sessionManager.on('sessionDestroyed', (sessionId) => {
+  app.log.info({ sessionId }, 'MCP session destroyed');
+});
+
+mcpServer.sessionManager.on('transportError', (sessionId, error) => {
+  app.log.error({ sessionId, error }, 'MCP transport error in session');
+});
+
+closeWithGrace({ delay: 500 }, async ({ signal, err }) => {
+  if (err) {
+    app.log.error({ err }, 'server closing with error');
+  } else {
+    app.log.info(`${signal} received, server closing`);
+  }
+  await mcpServer.shutdown();
+  await app.close();
+});
+
+await app.ready();
+
+await app.listen({
+  host: '127.0.0.1',
+  port: 9080,
+  listenTextResolver: (address) => `(Bearer) MCP Streamable HTTP Server listening at ${address}`
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "@fastify/middie": "^9.0.3",
         "@types/node": "^24.0.1",
         "c8": "^10.1.3",
         "close-with-grace": "^2.2.0",
@@ -632,8 +633,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "5.0.3",
@@ -680,6 +680,29 @@
       "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/middie": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-9.0.3.tgz",
+      "integrity": "sha512-7OYovKXp9UKYeVMcjcFLMcSpoMkmcZmfnG+eAvtdiatN35W7c+r9y1dRfpA+pfFVNuHGGqI3W+vDTmjvcfLcMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/@fastify/proxy-addr": {
@@ -8175,7 +8198,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git+https://github.com/flaviodelgrosso/fastify-mcp-streamable-http.git"
   },
   "scripts": {
-    "dev": "node --no-warnings --watch examples/demo.ts",
+    "dev": "node --no-warnings --watch examples/${npm_config_example:-basic}.ts",
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "prepare": "husky",
@@ -47,6 +47,7 @@
     "fastify": "^5.x"
   },
   "dependencies": {
+    "@fastify/middie": "^9.0.3",
     "fastify-plugin": "^5.0.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { requireBearerAuth, type BearerAuthMiddlewareOptions } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
@@ -7,6 +8,7 @@ import { FastifyMcpStreamableHttpServer } from './server.ts';
 export type FastifyMcpStreamableHttpOptions = {
   server: Server;
   endpoint?: string;
+  bearerAuthMiddlewareOptions?: BearerAuthMiddlewareOptions;
 };
 
 const kFastifyMcp = Symbol('fastifyMcp');
@@ -18,9 +20,14 @@ const FastifyMcpStreamableHttp: FastifyPluginAsync<FastifyMcpStreamableHttpOptio
   app,
   options
 ) => {
-  const { server, endpoint } = options;
+  const { server, endpoint, bearerAuthMiddlewareOptions } = options;
 
   const mcp = new FastifyMcpStreamableHttpServer(app, server, endpoint);
+
+  if (bearerAuthMiddlewareOptions) {
+    await app.register(import('@fastify/middie'));
+    app.use(requireBearerAuth(bearerAuthMiddlewareOptions));
+  }
 
   // Decorate the Fastify instance with the MCP server for external access
   app.decorate(kFastifyMcp, mcp);


### PR DESCRIPTION
This pull request introduces multiple changes, primarily focusing on adding support for Bearer token authentication to the `FastifyMcpStreamableHttp` plugin and improving the examples and configuration for better usability. Below is a summary of the most important changes grouped by theme:

Closes #3 

### Bearer Token Authentication Support:
* Added an optional `bearerAuthMiddlewareOptions` parameter to the `FastifyMcpStreamableHttp` plugin, enabling Bearer token authentication via the `@modelcontextprotocol/sdk` package. (`src/index.ts`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R11) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-R31)
* Integrated the `@fastify/middie` middleware to support Bearer token authentication when the `bearerAuthMiddlewareOptions` parameter is provided. (`src/index.ts`, [src/index.tsL21-R31](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-R31))

### New Example for Bearer Token Authentication:
* Introduced a new example file, `examples/bearer.ts`, demonstrating how to set up the `FastifyMcpStreamableHttp` plugin with Bearer token authentication, including a mock implementation of `OAuthTokenVerifier` and event handlers for MCP sessions.

### Improvements to Existing Examples:
* Renamed `examples/demo.ts` to `examples/basic.ts` and updated the server's `listenTextResolver` to include a `(Basic)` prefix for better distinction. (`examples/basic.ts`, [examples/basic.tsL78-R78](diffhunk://#diff-79a6ca7f16889f4f26bb8a4d33404a7f875625b130d17403d7da379b76e80c81L78-R78))

### Configuration Enhancements:
* Updated the `dev` script in `package.json` to dynamically select the example file to run based on the `npm_config_example` environment variable, defaulting to `basic`. (`package.json`, [package.jsonL31-R31](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31))
* Added `@fastify/middie` as a new dependency to support middleware functionality. (`package.json`, [package.jsonR50](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50))